### PR TITLE
Print emergency cards

### DIFF
--- a/src/components/Admin/AdminEmergencyCards.jsx
+++ b/src/components/Admin/AdminEmergencyCards.jsx
@@ -1,6 +1,23 @@
 import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Button } from '@material-ui/core';
+import PrintIcon from '@material-ui/icons/Print';
 import GetCardInfo from './GetCardInfo';
 
+const Container = styled.div`
+    width: 90%;
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+`;
+
+const RemovePrint = styled.div`
+    @media print {
+        display: none;
+    }
+`;
 
 function EmergencyCard(props) {
     const { user } = props;
@@ -18,11 +35,16 @@ function EmergencyCard(props) {
     let team = teamMembers.filter(member => member._id !== user._id);
 
     return (
-        <div className="printCard">
+        <>
+        <RemovePrint className=".removePrint">
+        <Button onClick={window.print}><PrintIcon /></Button>
+        </RemovePrint>
+        <Container className="printCard">
         {team.map((member) => (            
             <GetCardInfo id={member._id}/>
         ))}
-        </div>
+        </Container>
+        </>
     );
 }
 

--- a/src/components/Admin/AdminForms.jsx
+++ b/src/components/Admin/AdminForms.jsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Paper, Grid } from '@material-ui/core';
+import { Paper, Grid, Container } from '@material-ui/core';
+import PermissionsComponent from './PermissionsComponent';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -11,6 +12,14 @@ const useStyles = makeStyles((theme) => ({
         textAlign: 'left',
         color: theme.palette.text.secondary,
     },
+    permissions: {
+        width: 400
+    },
+    permissionsHeader: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        borderBottom: '1px solid #000'
+    }
 }));
 
 const AdminForms = ({user}) =>{
@@ -26,7 +35,7 @@ const AdminForms = ({user}) =>{
         })();
     }, [setTeamMembers, user]);
     
-    
+
     return (
         <>
             <div className={classes.root}>
@@ -61,6 +70,13 @@ const AdminForms = ({user}) =>{
                     </Grid>
                 </Grid>
             </div>
+            <Container className={classes.permissions}>
+                <h2>Permissions</h2>
+                <div className={classes.permissionsHeader}><h4>Member</h4><h4>Is Admin</h4></div>
+                {teamMembers.map(member => (
+                    <PermissionsComponent member={member} />
+                ))}
+            </Container>
         </>
     );
 }

--- a/src/components/Admin/GetCardInfo.jsx
+++ b/src/components/Admin/GetCardInfo.jsx
@@ -1,13 +1,28 @@
 import React, {useState, useEffect} from 'react';
 import { useParams } from 'react-router-dom';
-import { makeStyles } from '@material-ui/core/styles';
-import { Card, CardContent, Typography } from '@material-ui/core';
+import { CardContent } from '@material-ui/core';
 import styled from 'styled-components';
+
+const Card = styled.div`
+    position: relative;
+    background-color: white;
+    border: 1px solid lightgrey;
+    border-radius: 5px;
+    height: 225px;
+    width: 450px;
+    text-align: left;
+    margin: 10px;
+
+    .title {
+        font-weight: bold;
+        margin-right: 10px;
+    }
+`;
 
 const QRCode = styled.img`
     position: absolute;
-    height: 100px;
-    width: 100px;
+    height: 80px;
+    width: 80px;
     z-index: 20;
     bottom: 10px;
     right: 10px;
@@ -19,20 +34,11 @@ const QRCode = styled.img`
     }
 `;
 
-const useStyles = makeStyles({
-    root: {
-        textAlign: 'left',
-        width: 500,
-    },
-    title: {
-        fontSize: 14,
-    },
-});
+
 
 const GetCardInfo = (props) => {
 
     const [member, setMember] = useState('');
-    const classes = useStyles();
     const { id } = useParams();
 
     let user_id;
@@ -54,29 +60,29 @@ const GetCardInfo = (props) => {
         <>
         {!!member ? (
 
-<Card key={member._id} className={classes.root} variant="outlined">
-                <div className="relative">
+<Card key={member._id} variant="outlined">
+        
             <CardContent>
-            <Typography className="title" component="h1">
-                Rider Name {member.parentForm.rider.firstName + " " + member.parentForm.rider.lastName}
-            </Typography>
-            <Typography component="h2">
-                Emergency Contact Name: {member.parentForm.emergencyContactOne.firstName}<br />
-                Emergency Contact Number: {member.parentForm.emergencyContactOne.phone.cell}
-            </Typography>
-            <Typography component="p">
+            <div>
+                Rider Name:  {member.parentForm.rider.firstName + " " + member.parentForm.rider.lastName}
+            </div>
+            <div>
+            Emergency Contact Name: {member.parentForm.emergencyContactOne.firstName}<br />
+            Emergency Contact Number:  {member.parentForm.emergencyContactOne.phone.cell}
+            </div>
+            <div component="p">
                 Medications and History: {member.allergies}<br />
                 Ibuprofen Release: {!!member.ibuprofenRelease ? 'Yes' : 'No'}
-            </Typography>
-            <Typography component="p">
+            </div>
+            <div component="p">
                 Insurance Company Name: {member.insurance.provider}<br />
                 Policy Number: {member.insurance.number}<br />
                 Group Name: {member.insurance.group}<br />
-            </Typography>
+            </div>
             </CardContent>
             
             <QRCode src={`https://api.qrserver.com/v1/create-qr-code/?data=http://localhost:3000/getCardInfo/${member._id}`} alt="qr-code"/>
-            </div>
+        
         </Card>
         ) : null}
         

--- a/src/components/Admin/PermissionsComponent.jsx
+++ b/src/components/Admin/PermissionsComponent.jsx
@@ -1,0 +1,57 @@
+import React, {useState} from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Checkbox } from '@material-ui/core';
+const useStyles = makeStyles((theme) => ({
+    memberPermissions: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '0 10px'
+    }
+}));
+
+const PermissionsComponent = ({member}) => {
+    const classes = useStyles();
+    const [isAdmin, setIsAdmin] = useState(member.isAdmin);
+
+    const _handleChange = async () => {
+        let updatedValue;
+        if (isAdmin) {
+            setIsAdmin(false);
+            updatedValue = false;
+        } else {
+            setIsAdmin(true)
+            updatedValue = true
+        }
+
+        let data = {
+            ...member,
+            isAdmin: updatedValue
+        }
+
+        //let response;
+        await fetch(`http://localhost:3333/user/update/${member._id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type' : 'application/json' },
+            body: JSON.stringify(data)
+          });
+        // const resdata = await response.json();
+        // console.log(resdata)
+
+    }
+
+    return (
+        <div className={classes.memberPermissions}>      
+            {member.firstName} {member.lastName}
+            <Checkbox
+        checked={isAdmin}
+        onChange={_handleChange}
+        inputProps={{ 'aria-label': 'primary checkbox' }}
+      />
+        </div>
+    )
+}
+
+
+
+export default PermissionsComponent;

--- a/src/index.css
+++ b/src/index.css
@@ -16,12 +16,10 @@ code {
   position: relative;
 }
 
+
 @media print {
   header, footer, .removePrint {
     display: none;
   }
 
-  .printCard {
-    margin-top: 20px;
-  }
 }


### PR DESCRIPTION
Display cards in browser side by side if window is big enough and added a print button to the page.  When print preview is displayed header, footer, and print button is removed only allowing for the actual cards to be printed